### PR TITLE
Add tests for different types of DMN validator input parameters

### DIFF
--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/AbstractValidatorTest.java
@@ -16,10 +16,19 @@
 
 package org.kie.dmn.validation;
 
+import java.io.File;
 import java.io.InputStreamReader;
 import java.io.Reader;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.core.util.DMNRuntimeUtil;
+import org.kie.dmn.model.v1_1.Definitions;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 public abstract class AbstractValidatorTest {
 
@@ -35,7 +44,21 @@ public abstract class AbstractValidatorTest {
         validator.dispose();
     }
 
-    protected Reader getReader( String filename ) {
-        return new InputStreamReader( getClass().getResourceAsStream( filename ) );
+    protected Reader getReader(final String resourceFileName ) {
+        return new InputStreamReader( getClass().getResourceAsStream( resourceFileName ) );
+    }
+
+    protected File getFile(final String resourceFileName ) {
+        return new File(this.getClass().getResource(resourceFileName).getFile());
+    }
+
+    protected Definitions getDefinitions(final String resourceName, final String namespace, final String modelName ) {
+        final DMNRuntime runtime = DMNRuntimeUtil.createRuntime(resourceName, this.getClass() );
+        final DMNModel dmnModel = runtime.getModel(namespace, modelName );
+        assertThat( dmnModel, notNullValue() );
+
+        final Definitions definitions = dmnModel.getDefinitions();
+        assertThat( definitions, notNullValue() );
+        return definitions;
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorArtifactTest.java
@@ -16,24 +16,50 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorArtifactTest extends AbstractValidatorTest {
 
     @Test
-    public void testASSOC_REFERENCES_NOT_EMPTY() {
+    public void testASSOC_REFERENCES_NOT_EMPTY_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testASSOC_REFERENCES_NOT_EMPTY_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" ),
+                getFile( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testASSOC_REFERENCES_NOT_EMPTY_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions( "artifact/ASSOC_REFERENCES_NOT_EMPTY.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "ASSOC_REFERENCES_NOT_EMPTY"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorAuthorityRequirementTest.java
@@ -16,69 +16,205 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorAuthorityRequirementTest extends AbstractValidatorTest {
 
     @Test
-    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_AUTH() {
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_AUTH_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_AUTH_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn"),
+                getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_DEC() {
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_AUTH_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn"),
+                getDefinitions("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "AUTHREQ_MISSING_DEPENDENCY_REQ_AUTH"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_DEC_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_DEC_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_INPUT() {
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_DEC_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn"),
+                getDefinitions("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_DEC.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "AUTHREQ_MISSING_DEPENDENCY_REQ_DEC"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_INPUT_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_INPUT_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testAUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE() {
+    public void testAUTH_REQ_MISSING_DEPENDENCY_REQ_INPUT_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn"),
+                getDefinitions("authorityrequirement/AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "AUTHREQ_MISSING_DEPENDENCY_REQ_INPUT"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testAUTHREQ_DEP_REQ_DEC_NOT_DECISION() {
+    public void testAUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn"),
+                getDefinitions("authorityrequirement/AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "AUTHREQ_DEP_REQ_AUTH_NOT_KNOWLEDGESOURCE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_DEC_NOT_DECISION_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_DEC_NOT_DECISION_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testAUTHREQ_DEP_REQ_INPUT_NOT_INPUT() {
+    public void testAUTHREQ_DEP_REQ_DEC_NOT_DECISION_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn"),
+                getDefinitions("authorityrequirement/AUTHREQ_DEP_REQ_DEC_NOT_DECISION.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "AUTHREQ_DEP_REQ_DEC_NOT_DECISION"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_INPUT_NOT_INPUT_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_INPUT_NOT_INPUT_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testAUTHREQ_DEP_REQ_INPUT_NOT_INPUT_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("authorityrequirement/AUTHREQ_DEP_REQ_INPUT_NOT_INPUT.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "AUTHREQ_DEP_REQ_INPUT_NOT_INPUT"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessContextTest.java
@@ -16,42 +16,112 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorBusinessContextTest extends AbstractValidatorTest {
 
     @Test
-    public void testORG_UNIT_DECISION_MADE_WRONG_TYPE() {
+    public void testORG_UNIT_DECISION_MADE_WRONG_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testORG_UNIT_DECISION_MADE_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn"),
+                getFile("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testORG_UNIT_DECISION_OWNED_WRONG_TYPE() {
+    public void testORG_UNIT_DECISION_MADE_WRONG_TYPE_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn"),
+                getDefinitions("businesscontext/ORG_UNIT_DECISION_MADE_WRONG_TYPE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "ORG_UNIT_DECISION_MADE_WRONG_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testORG_UNIT_DECISION_OWNED_WRONG_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testORG_UNIT_DECISION_OWNED_WRONG_TYPE_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testPERF_INDICATOR_IMP_DECISION_WRONG_TYPE() {
+    public void testORG_UNIT_DECISION_OWNED_WRONG_TYPE_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn"),
+                getDefinitions("businesscontext/ORG_UNIT_DECISION_OWNED_WRONG_TYPE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "ORG_UNIT_DECISION_OWNED_WRONG_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testPERF_INDICATOR_IMP_DECISION_WRONG_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testPERF_INDICATOR_IMP_DECISION_WRONG_TYPE_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testPERF_INDICATOR_IMP_DECISION_WRONG_TYPE_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("businesscontext/PERF_INDICATOR_IMP_DECISION_WRONG_TYPE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "PERF_INDICATOR_IMP_DECISION_WRONG_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorBusinessKnowledgeModelTest.java
@@ -22,6 +22,8 @@ import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATIO
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
@@ -30,28 +32,94 @@ import org.kie.dmn.api.core.DMNMessageType;
 public class ValidatorBusinessKnowledgeModelTest extends AbstractValidatorTest {
 
     @Test
-    public void testBKM_MISSING_VAR() {
+    public void testBKM_MISSING_VAR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("businessknowledgemodel/BKM_MISSING_VAR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        }
+    }
+
+    @Test
+    public void testBKM_MISSING_VAR_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("businessknowledgemodel/BKM_MISSING_VAR.dmn"),
+                getFile("businessknowledgemodel/BKM_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
     @Test
-    public void testBKM_MISMATCH_VAR() {
+    public void testBKM_MISSING_VAR_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("businessknowledgemodel/BKM_MISMATCH_VAR.dmn"),
+                getDefinitions("businessknowledgemodel/BKM_MISSING_VAR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "BKM_MISSING_VAR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+    }
+
+    @Test
+    public void testBKM_MISMATCH_VAR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("businessknowledgemodel/BKM_MISMATCH_VAR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        }
+    }
+
+    @Test
+    public void testBKM_MISMATCH_VAR_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("businessknowledgemodel/BKM_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
     @Test
-    public void testBKM_MISSING_EXPR() {
+    public void testBKM_MISMATCH_VAR_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("businessknowledgemodel/BKM_MISSING_EXPR.dmn"),
+                getDefinitions("businessknowledgemodel/BKM_MISMATCH_VAR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "BKM_MISSING_VAR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+    }
+
+    @Test
+    public void testBKM_MISSING_EXPR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("businessknowledgemodel/BKM_MISSING_EXPR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        }
+    }
+
+    @Test
+    public void testBKM_MISSING_EXPR_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("businessknowledgemodel/BKM_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+    }
+
+    @Test
+    public void testBKM_MISSING_EXPR_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("businessknowledgemodel/BKM_MISSING_EXPR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "BKM_MISSING_EXPR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorContextTest.java
@@ -22,6 +22,8 @@ import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATIO
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
@@ -32,9 +34,21 @@ import org.kie.dmn.model.v1_1.ContextEntry;
 public class ValidatorContextTest extends AbstractValidatorTest {
 
     @Test
-    public void testCONTEXT_MISSING_EXPR() {
+    public void testCONTEXT_MISSING_EXPR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("context/CONTEXT_MISSING_EXPR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        }
+    }
+
+    @Test
+    public void testCONTEXT_MISSING_EXPR_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("context/CONTEXT_MISSING_EXPR.dmn"),
+                getFile("context/CONTEXT_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION))); // this is schema validation
@@ -42,18 +56,65 @@ public class ValidatorContextTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testCONTEXT_MISSING_ENTRIES() {
+    public void testCONTEXT_MISSING_EXPR_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("context/CONTEXT_MISSING_ENTRIES.dmn"),
+                getDefinitions("context/CONTEXT_MISSING_EXPR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "CONTEXT_MISSING_EXPR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+    }
+
+    @Test
+    public void testCONTEXT_MISSING_ENTRIES_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("context/CONTEXT_MISSING_ENTRIES.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        }
+    }
+
+    @Test
+    public void testCONTEXT_MISSING_ENTRIES_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("context/CONTEXT_MISSING_ENTRIES.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
     @Test
-    public void testCONTEXT_ENTRY_MISSING_VARIABLE() {
+    public void testCONTEXT_MISSING_ENTRIES_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn"),
+                getDefinitions("context/CONTEXT_MISSING_ENTRIES.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "CONTEXT_MISSING_EXPR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+    }
+
+    @Test
+    public void testCONTEXT_ENTRY_MISSING_VARIABLE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+            // check that it reports and error for the second context entry, but not for the last one
+            final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
+            assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+        }
+    }
+
+    @Test
+    public void testCONTEXT_ENTRY_MISSING_VARIABLE_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
@@ -63,19 +124,77 @@ public class ValidatorContextTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testCONTEXT_DUP_ENTRY() {
+    public void testCONTEXT_ENTRY_MISSING_VARIABLE_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("context/CONTEXT_DUP_ENTRY.dmn"),
+                getDefinitions("context/CONTEXT_ENTRY_MISSING_VARIABLE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "CONTEXT_MISSING_EXPR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        // check that it reports and error for the second context entry, but not for the last one
+        final ContextEntry ce = (ContextEntry) validate.get(0).getSourceReference();
+        assertThat(((Context) ce.getParent()).getContextEntry().indexOf(ce), is(1));
+    }
+
+    @Test
+    public void testCONTEXT_DUP_ENTRY_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("context/CONTEXT_DUP_ENTRY.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+        }
+    }
+
+    @Test
+    public void testCONTEXT_DUP_ENTRY_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("context/CONTEXT_DUP_ENTRY.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
     }
 
     @Test
-    public void testCONTEXT_ENTRY_NOTYPEREF() {
+    public void testCONTEXT_DUP_ENTRY_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("context/CONTEXT_ENTRY_NOTYPEREF.dmn"),
+                getDefinitions("context/CONTEXT_DUP_ENTRY.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "CONTEXT_DUP_ENTRY"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.DUPLICATE_NAME)));
+    }
+
+    @Test
+    public void testCONTEXT_ENTRY_NOTYPEREF_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("context/CONTEXT_ENTRY_NOTYPEREF.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+        }
+    }
+
+    @Test
+    public void testCONTEXT_ENTRY_NOTYPEREF_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("context/CONTEXT_ENTRY_NOTYPEREF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
+    }
+
+    @Test
+    public void testCONTEXT_ENTRY_NOTYPEREF_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("context/CONTEXT_ENTRY_NOTYPEREF.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "CONTEXT_ENTRY_NOTYPEREF"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_TYPE_REF)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDMNElementReferenceTest.java
@@ -16,27 +16,58 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorDMNElementReferenceTest extends AbstractValidatorTest {
 
     @Test
-    public void testELEMREF_NOHASH() {
+    public void testELEMREF_NOHASH_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("dmnelementref/ELEMREF_NOHASH.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testELEMREF_NOHASH_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("dmnelementref/ELEMREF_NOHASH.dmn"),
+                getFile("dmnelementref/ELEMREF_NOHASH.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
+
+    @Test
+    public void testELEMREF_NOHASH_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("dmnelementref/ELEMREF_NOHASH.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "ELEMREF_NOHASH"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(3));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_HREF_SYNTAX)));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTableTest.java
@@ -16,34 +16,69 @@
 
 package org.kie.dmn.validation;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
-import org.kie.dmn.model.v1_1.Context;
-import org.kie.dmn.model.v1_1.ContextEntry;
-
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.kie.dmn.validation.DMNValidator.Validation.*;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
 
 public class ValidatorDecisionTableTest
         extends AbstractValidatorTest {
 
     @Test
-    public void testDTABLE_EMPTY_ENTRY() {
+    public void testDTABLE_EMPTY_ENTRY_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("DTABLE_EMPTY_ENTRY.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+        }
+    }
+
+    @Test
+    public void testDTABLE_EMPTY_ENTRY_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("DTABLE_EMPTY_ENTRY.dmn"),
+                getFile("DTABLE_EMPTY_ENTRY.dmn"),
                 VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
     }
 
     @Test
-    public void testDTABLE_MULTIPLEOUT_NAME() {
-        List<DMNMessage> validate = validator.validate( getReader( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+    public void testDTABLE_EMPTY_ENTRY_DefintionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("DTABLE_EMPTY_ENTRY.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DTABLE_PRIORITY_MISSING_OUTVALS"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_EXPRESSION)));
+    }
+
+    @Test
+    public void testDTABLE_MULTIPLEOUT_NAME_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" )) {
+            List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+        }
+    }
+
+    @Test
+    public void testDTABLE_MULTIPLEOUT_NAME_FileInput() {
+        List<DMNMessage> validate = validator.validate( getFile( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
@@ -51,15 +86,70 @@ public class ValidatorDecisionTableTest
     }
 
     @Test
-    public void testDTABLE_PRIORITY_MISSING_OUTVALS() {
-        List<DMNMessage> validate = validator.validate( getReader( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+    public void testDTABLE_MULTIPLEOUT_NAME_DefinitionsInput() {
+        List<DMNMessage> validate = validator.validate(
+                getDefinitions( "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "DTABLE_MULTIPLEOUTPUT_WRONG_OUTPUT"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 5 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_NAME ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_TYPE_REF ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.INVALID_NAME ) ) );
+    }
+
+    @Test
+    public void testDTABLE_PRIORITY_MISSING_OUTVALS_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" )) {
+            List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+        }
+    }
+
+    @Test
+    public void testDTABLE_PRIORITY_MISSING_OUTVALS_FileInput() {
+        List<DMNMessage> validate = validator.validate( getFile( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
     }
 
     @Test
-    public void testDTABLE_SINGLEOUT_NONAME() {
-        List<DMNMessage> validate = validator.validate( getReader( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+    public void testDTABLE_PRIORITY_MISSING_OUTVALS_DefinitionsInput() {
+        List<DMNMessage> validate = validator.validate(
+                getDefinitions( "DTABLE_PRIORITY_MISSING_OUTVALS.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "DTABLE_PRIORITY_MISSING_OUTVALS"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.isEmpty(), is( false ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_OUTPUT_VALUES ) ) );
+    }
+
+    @Test
+    public void testDTABLE_SINGLEOUT_NONAME_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" )) {
+            List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+        }
+    }
+
+    @Test
+    public void testDTABLE_SINGLEOUT_NONAME_FileInput() {
+        List<DMNMessage> validate = validator.validate( getFile( "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn" ), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );
+    }
+
+    @Test
+    public void testDTABLE_SINGLEOUT_NONAME_DefinitionsInput() {
+        List<DMNMessage> validate = validator.validate(
+                getDefinitions("DTABLE_SINGLEOUTPUT_WRONG_OUTPUT.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DTABLE_SINGLEOUTPUT_WRONG_OUTPUT"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_NAME ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.ILLEGAL_USE_OF_TYPEREF ) ) );

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorDecisionTest.java
@@ -16,109 +16,351 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorDecisionTest extends AbstractValidatorTest {
 
     @Test
-    public void testDECISION_MISSING_EXPR() {
+    public void testDECISION_MISSING_EXPR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_MISSING_EXPR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+        }
+    }
+
+    @Test
+    public void testDECISION_MISSING_EXPR_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_MISSING_EXPR.dmn"),
+                getFile("decision/DECISION_MISSING_EXPR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
     }
 
     @Test
-    public void testDECISION_MISSING_VAR() {
+    public void testDECISION_MISSING_EXPR_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_MISSING_VAR.dmn"),
+                getDefinitions("decision/DECISION_MISSING_EXPR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_MISSING_EXPR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertThat(validate.get(0).toString(), validate.get(0).getMessageType(), is(DMNMessageType.MISSING_EXPRESSION));
+    }
+
+    @Test
+    public void testDECISION_MISSING_VAR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_MISSING_VAR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        }
+    }
+
+    @Test
+    public void testDECISION_MISSING_VAR_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("decision/DECISION_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
     @Test
-    public void testDECISION_MISSING_VARbis() {
+    public void testDECISION_MISSING_VAR_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_MISSING_VARbis.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+                getDefinitions("decision/DECISION_MISSING_VAR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_MISSING_VAR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
     @Test
-    public void testDECISION_MISMATCH_VAR() {
+    public void testDECISION_MISSING_VARbis_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_MISSING_VARbis.dmn")) {
+            final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        }
+    }
+
+    @Test
+    public void testDECISION_MISSING_VARbis_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_MISMATCH_VAR.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+                getFile("decision/DECISION_MISSING_VARbis.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+    }
+
+    @Test
+    public void testDECISION_MISSING_VARbis_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_MISSING_VARbis.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_MISSING_VARbis"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+    }
+
+    @Test
+    public void testDECISION_MISMATCH_VAR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_MISMATCH_VAR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        }
+    }
+
+    @Test
+    public void testDECISION_MISMATCH_VAR_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("decision/DECISION_MISMATCH_VAR.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }
 
     @Test
-    public void testDECISION_MULTIPLE_EXPRESSIONS() {
+    public void testDECISION_MISMATCH_VAR_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+                getDefinitions("decision/DECISION_MISMATCH_VAR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_MISSING_VAR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+    }
+
+    @Test
+    public void testDECISION_MULTIPLE_EXPRESSIONS_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn")) {
+            final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
+        }
+    }
+
+    @Test
+    public void testDECISION_MULTIPLE_EXPRESSIONS_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
     }
 
     @Test
-    public void testDECISION_PERF_INDICATOR_WRONG_TYPE() {
+    public void testDECISION_MULTIPLE_EXPRESSIONS_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+                getDefinitions("decision/DECISION_MULTIPLE_EXPRESSIONS.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_MULTIPLE_EXPRESSIONS"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
     }
 
     @Test
-    public void testDECISION_DECISION_MAKER_WRONG_TYPE() {
+    public void testDECISION_PERF_INDICATOR_WRONG_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testDECISION_PERF_INDICATOR_WRONG_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+                getFile("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testDECISION_DECISION_OWNER_WRONG_TYPE() {
+    public void testDECISION_PERF_INDICATOR_WRONG_TYPE_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
-        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
-        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
-    }
-
-
-    @Test
-    public void testDECISION_CYCLIC_DEPENDENCY() {
-        final List<DMNMessage> validate = validator.validate( getReader("decision/DECISION_CYCLIC_DEPENDENCY.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+                getDefinitions("decision/DECISION_PERF_INDICATOR_WRONG_TYPE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_PERF_INDICATOR_WRONG_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE() {
-        final List<DMNMessage> validate = validator.validate( getReader("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+    public void testDECISION_DECISION_MAKER_WRONG_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testDECISION_DECISION_MAKER_WRONG_TYPE_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_DECISION_MAKER_WRONG_TYPE_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_DECISION_MAKER_WRONG_TYPE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_DECISION_MAKER_WRONG_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_DECISION_OWNER_WRONG_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testDECISION_DECISION_OWNER_WRONG_TYPE_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_DECISION_OWNER_WRONG_TYPE_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_DECISION_OWNER_WRONG_TYPE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_DECISION_MAKER_WRONG_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_CYCLIC_DEPENDENCY_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY.dmn")) {
+            final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testDECISION_CYCLIC_DEPENDENCY_FileInput() {
+        final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_CYCLIC_DEPENDENCY_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_CYCLIC_DEPENDENCY.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_CYCLIC_DEPENDENCY"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn")) {
+            final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_FileInput() {
+        final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
     }
 
     @Test
-    public void testDECISION_DEADLY_DIAMOND() {
-        final List<DMNMessage> validate = validator.validate( getReader("decision/DECISION_DEADLY_DIAMOND.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+    public void testDECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_CYCLIC_DEPENDENCY_SELF_REFERENCE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.REQ_NOT_FOUND)));
+    }
+
+    @Test
+    public void testDECISION_DEADLY_DIAMOND_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_DEADLY_DIAMOND.dmn")) {
+            final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        }
+    }
+
+    @Test
+    public void testDECISION_DEADLY_DIAMOND_FileInput() {
+        final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_DEADLY_DIAMOND.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
     }
 
     @Test
-    public void testDECISION_DEADLY_KITE() {
-        final List<DMNMessage> validate = validator.validate( getReader("decision/DECISION_DEADLY_KITE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+    public void testDECISION_DEADLY_DIAMOND_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_DEADLY_DIAMOND.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_DEADLY_DIAMOND"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
+    @Test
+    public void testDECISION_DEADLY_KITE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("decision/DECISION_DEADLY_KITE.dmn")) {
+            final List<DMNMessage> validate = validator.validate( reader, VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        }
+    }
+
+    @Test
+    public void testDECISION_DEADLY_KITE_FileInput() {
+        final List<DMNMessage> validate = validator.validate( getFile("decision/DECISION_DEADLY_KITE.dmn"), VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION );
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
+    @Test
+    public void testDECISION_DEADLY_KITE_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("decision/DECISION_DEADLY_KITE.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "DECISION_DEADLY_KITE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION );
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
     }
 }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInformationRequirementTest.java
@@ -16,23 +16,39 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
 
     @Test
-    public void testINFOREQ_MISSING_INPUT() {
+    public void testINFOREQ_MISSING_INPUT_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testINFOREQ_MISSING_INPUT_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" ),
+                getFile( "informationrequirement/INFOREQ_MISSING_INPUT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
@@ -40,9 +56,33 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testINFOREQ_INPUT_NOT_INPUTDATA() {
+    public void testINFOREQ_MISSING_INPUT_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" ),
+                getDefinitions( "informationrequirement/INFOREQ_MISSING_INPUT.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "INFOREQ_MISSING_INPUT"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testINFOREQ_INPUT_NOT_INPUTDATA_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testINFOREQ_INPUT_NOT_INPUTDATA_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
@@ -50,9 +90,33 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testINFOREQ_MISSING_DECISION() {
+    public void testINFOREQ_INPUT_NOT_INPUTDATA_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" ),
+                getDefinitions( "informationrequirement/INFOREQ_INPUT_NOT_INPUTDATA.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "INFOREQ_INPUT_NOT_INPUTDATA"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testINFOREQ_MISSING_DECISION_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testINFOREQ_MISSING_DECISION_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile( "informationrequirement/INFOREQ_MISSING_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
@@ -60,10 +124,46 @@ public class ValidatorInformationRequirementTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testINFOREQ_DECISION_NOT_DECISION() {
+    public void testINFOREQ_MISSING_DECISION_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" ),
+                getDefinitions( "informationrequirement/INFOREQ_MISSING_DECISION.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "INFOREQ_MISSING_DECISION"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testINFOREQ_DECISION_NOT_DECISION_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testINFOREQ_DECISION_NOT_DECISION_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testINFOREQ_DECISION_NOT_DECISION_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions( "informationrequirement/INFOREQ_DECISION_NOT_DECISION.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "INFOREQ_DECISION_NOT_DECISION"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorInputDataTest.java
@@ -22,6 +22,8 @@ import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATIO
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
@@ -30,19 +32,63 @@ import org.kie.dmn.api.core.DMNMessageType;
 public class ValidatorInputDataTest extends AbstractValidatorTest {
 
     @Test
-    public void testINPUT_MISSING_VAR() {
+    public void testINPUT_MISSING_VAR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("inputdata/INPUTDATA_MISSING_VAR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+        }
+    }
+
+    @Test
+    public void testINPUT_MISSING_VAR_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("inputdata/INPUTDATA_MISSING_VAR.dmn"),
+                getFile("inputdata/INPUTDATA_MISSING_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
     }
 
     @Test
-    public void testINPUT_MISMATCH_VAR() {
+    public void testINPUT_MISSING_VAR_DefintionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("inputdata/INPUTDATA_MISMATCH_VAR.dmn"),
+                getDefinitions("inputdata/INPUTDATA_MISSING_VAR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "INPUTDATA_MISSING_VAR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.MISSING_VARIABLE)));
+    }
+
+    @Test
+    public void testINPUT_MISMATCH_VAR_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("inputdata/INPUTDATA_MISMATCH_VAR.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+        }
+    }
+
+    @Test
+    public void testINPUT_MISMATCH_VAR_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("inputdata/INPUTDATA_MISMATCH_VAR.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
+    }
+
+    @Test
+    public void testINPUT_MISMATCH_VAR_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("inputdata/INPUTDATA_MISMATCH_VAR.dmn",
+                               "https://github.com/kiegroup/kie-dmn",
+                               "INPUTDATA_MISSING_VAR"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.VARIABLE_NAME_MISMATCH)));
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeRequirementTest.java
@@ -22,6 +22,8 @@ import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATIO
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
 import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
@@ -30,9 +32,21 @@ import org.kie.dmn.api.core.DMNMessageType;
 public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
 
     @Test
-    public void testKNOWREQ_MISSING_BKM() {
+    public void testKNOWREQ_MISSING_BKM_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testKNOWREQ_MISSING_BKM_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" ),
+                getFile( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
@@ -40,10 +54,46 @@ public class ValidatorKnowledgeRequirementTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testKNOWREQ_REQ_DECISION_NOT_BKM() {
+    public void testKNOWREQ_MISSING_BKM_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" ),
+                getDefinitions( "knowledgerequirement/KNOWREQ_MISSING_BKM.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "KNOWREQ_MISSING_BKM"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testKNOWREQ_REQ_DECISION_NOT_BKM_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testKNOWREQ_REQ_DECISION_NOT_BKM_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testKNOWREQ_REQ_DECISION_NOT_BKM_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions( "knowledgerequirement/KNOWREQ_REQ_DECISION_NOT_BKM.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "KNOWREQ_REQ_DECISION_NOT_BKM"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 2 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.MISSING_EXPRESSION ) ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorKnowledgeSourceTest.java
@@ -16,33 +16,81 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorKnowledgeSourceTest extends AbstractValidatorTest {
 
     @Test
-    public void testKNOW_SOURCE_MISSING_OWNER() {
+    public void testKNOW_SOURCE_MISSING_OWNER_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testKNOW_SOURCE_MISSING_OWNER_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" ),
+                getFile( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }
 
     @Test
-    public void testKNOW_SOURCE_OWNER_NOT_ORG_UNIT() {
+    public void testKNOW_SOURCE_MISSING_OWNER_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" ),
+                getDefinitions( "knowledgesource/KNOW_SOURCE_MISSING_OWNER.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "KNOW_SOURCE_MISSING_OWNER"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 1 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testKNOW_SOURCE_OWNER_NOT_ORG_UNIT_ReaderInput() throws IOException {
+        try (final Reader reader = getReader( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" )) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+            assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+        }
+    }
+
+    @Test
+    public void testKNOW_SOURCE_OWNER_NOT_ORG_UNIT_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn" ),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
+        assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
+    }
+
+    @Test
+    public void testKNOW_SOURCE_OWNER_NOT_ORG_UNIT_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions( "knowledgesource/KNOW_SOURCE_OWNER_NOT_ORG_UNIT.dmn",
+                                "https://github.com/kiegroup/kie-dmn",
+                                "KNOW_SOURCE_OWNER_NOT_ORG_UNIT"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat( ValidatorUtil.formatMessages( validate ), validate.size(), is( 3 ) );
         assertTrue( validate.stream().anyMatch( p -> p.getMessageType().equals( DMNMessageType.REQ_NOT_FOUND ) ) );
     }

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -26,6 +26,7 @@ import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URISyntaxException;
 import java.util.List;
 import org.junit.Ignore;
@@ -55,7 +56,7 @@ public class ValidatorTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testMACD() {
+    public void testMACDInputDefinitions() {
         DMNRuntime runtime = DMNRuntimeUtil.createRuntime( "MACD-enhanced_iteration.dmn", DMNInputRuntimeTest.class );
         DMNModel dmnModel = runtime.getModel( "http://www.trisotech.com/definitions/_6cfe7d88-6741-45d1-968c-b61a597d0964", "MACD-enhanced iteration" );
         assertThat( dmnModel, notNullValue() );
@@ -66,6 +67,14 @@ public class ValidatorTest extends AbstractValidatorTest {
         List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(definitions, VALIDATE_MODEL, VALIDATE_COMPILATION);
 
         assertThat( messages.toString(), messages.size(), is( 0 ) );
+    }
+
+    @Test
+    public void testMACDInputReader() throws IOException {
+        try (final Reader reader = new InputStreamReader(getClass().getResourceAsStream("/org/kie/dmn/core/MACD-enhanced_iteration.dmn") )) {
+            List<DMNMessage> messages = DMNValidatorFactory.newValidator().validate(reader, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat( messages.toString(), messages.size(), is( 0 ) );
+        }
     }
 
     private Definitions utilDefinitions(String filename, String modelName) {

--- a/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
+++ b/kie-dmn/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTypeRefTest.java
@@ -16,33 +16,68 @@
 
 package org.kie.dmn.validation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
-import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
-
-import java.net.URISyntaxException;
+import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
+
 import org.junit.Test;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_COMPILATION;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_MODEL;
+import static org.kie.dmn.validation.DMNValidator.Validation.VALIDATE_SCHEMA;
+
 public class ValidatorTypeRefTest extends AbstractValidatorTest {
 
     @Test
-    public void testTYPEREF_NO_FEEL_TYPE() {
+    public void testTYPEREF_NO_FEEL_TYPE_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("typeref/TYPEREF_NO_FEEL_TYPE.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testTYPEREF_NO_FEEL_TYPE_FileInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("typeref/TYPEREF_NO_FEEL_TYPE.dmn"),
+                getFile("typeref/TYPEREF_NO_FEEL_TYPE.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
     }
 
     @Test
-    public void testTYPEREF_NO_NS() throws URISyntaxException {
+    public void testTYPEREF_NO_FEEL_TYPE_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("typeref/TYPEREF_NO_NS.dmn"),
+                getDefinitions("typeref/TYPEREF_NO_FEEL_TYPE.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_FEEL_TYPE"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_REF_NOT_FOUND)));
+    }
+
+    @Test
+    public void testTYPEREF_NO_NS_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("typeref/TYPEREF_NO_NS.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testTYPEREF_NO_NS_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("typeref/TYPEREF_NO_NS.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.FAILED_XML_VALIDATION)));
@@ -50,9 +85,30 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testTYPEREF_NOT_FEEL_NOT_DEF() {
+    public void testTYPEREF_NO_NS_DefinitionsInput() {
         final List<DMNMessage> validate = validator.validate(
-                getReader("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn"),
+                getDefinitions("typeref/TYPEREF_NO_NS.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NO_NS"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(1));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+    }
+
+    @Test
+    public void testTYPEREF_NOT_FEEL_NOT_DEF_ReaderInput() throws IOException {
+        try (final Reader reader = getReader("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
+            assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+        }
+    }
+
+    @Test
+    public void testTYPEREF_NOT_FEEL_NOT_DEF_FileInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
         assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
@@ -60,13 +116,47 @@ public class ValidatorTypeRefTest extends AbstractValidatorTest {
     }
 
     @Test
-    public void testTYPEREF_NOT_FEEL_NOT_DEF_valid() {
+    public void testTYPEREF_NOT_FEEL_NOT_DEF_DefinitionsInput() {
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(2));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.INVALID_NAME)));
+        assertTrue(validate.stream().anyMatch(p -> p.getMessageType().equals(DMNMessageType.TYPE_DEF_NOT_FOUND)));
+    }
+
+    @Test
+    public void testTYPEREF_NOT_FEEL_NOT_DEF_valid_ResourceInput() throws IOException {
+        // DROOLS-1433
+        // the assumption is that the following document TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn should NOT contain any DMNMessageTypeId.TYPEREF_NOT_FEEL_NOT_DEF at all
+        // the test also highlight typically in a DMN model many nodes would not define a typeRef, resulting in a large number of false negative
+        try (final Reader reader = getReader("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn")) {
+            final List<DMNMessage> validate = validator.validate(
+                    reader,
+                    VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+            assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+        }
+    }
+
+    @Test
+    public void testTYPEREF_NOT_FEEL_NOT_DEF_valid_FileInput() {
         // DROOLS-1433
         // the assumption is that the following document TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn should NOT contain any DMNMessageTypeId.TYPEREF_NOT_FEEL_NOT_DEF at all
         // the test also highlight typically in a DMN model many nodes would not define a typeRef, resulting in a large number of false negative
         final List<DMNMessage> validate = validator.validate(
-                getReader("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn"),
+                getFile("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn"),
                 VALIDATE_SCHEMA, VALIDATE_MODEL, VALIDATE_COMPILATION);
+        assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
+    }
+
+    @Test
+    public void testTYPEREF_NOT_FEEL_NOT_DEF_valid_DefinitionsInput() {
+        // DROOLS-1433
+        // the assumption is that the following document TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn should NOT contain any DMNMessageTypeId.TYPEREF_NOT_FEEL_NOT_DEF at all
+        // the test also highlight typically in a DMN model many nodes would not define a typeRef, resulting in a large number of false negative
+        final List<DMNMessage> validate = validator.validate(
+                getDefinitions("typeref/TYPEREF_NOT_FEEL_NOT_DEF_valid.dmn", "https://github.com/kiegroup/kie-dmn", "TYPEREF_NOT_FEEL_NOT_DEF_valid"),
+                VALIDATE_MODEL, VALIDATE_COMPILATION);
         assertThat(ValidatorUtil.formatMessages(validate), validate.size(), is(0));
     }
 }


### PR DESCRIPTION
I found out that the reason why we didn't catch the false positives was because we were testing the validation only with validate method that takes Reader as an input parameter. However there are 2 other overloaded versions of validate method which take Definitions and File input parameters. 

- These new tests contain the same tests we had but with different types of input parameters of validate method.
- There is a bug that validate(Definitions, ...) behaves differently than validate(File, ...) or validate(Reader, ...) - it looks like that QName is not populated with a namespace when parsing from File or Reader. I will try to create a reproducer for this behaviour. 
- Next step is to create validation rules + tests that will validate also namespace of type references. 

@etirelli @tarilabs could you please review? 